### PR TITLE
refactoring pre-commitable commands

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -72,7 +72,7 @@ abstract class BaseCommand extends ComposerBaseCommand implements BaseCommandInt
     final protected function addComposerScript(array $scripts): void
     {
         $composerFileContents = $this->readComposerJsonFile();
-        $composerFileContents['scripts'][$this->getComposerScriptName()] = $scripts;
+        $composerFileContents['scripts'][$this->getComposerScriptName()] = array_values($scripts);
         $this->writeComposerJsonFile($composerFileContents);
     }
 

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -23,6 +23,7 @@ namespace SebSept\PsDevToolsPlugin\Command;
 use Composer\Command\BaseCommand as ComposerBaseCommand;
 use Composer\Json\JsonFile;
 use Exception;
+use SebSept\PsDevToolsPlugin\Command\Contract\BaseCommandInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Command/Contract/BaseCommandInterface.php
+++ b/src/Command/Contract/BaseCommandInterface.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace SebSept\PsDevToolsPlugin\Command;
+namespace SebSept\PsDevToolsPlugin\Command\Contract;
 
 interface BaseCommandInterface
 {

--- a/src/Command/Contract/PreCommitRegistrableCommand.php
+++ b/src/Command/Contract/PreCommitRegistrableCommand.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-namespace SebSept\PsDevToolsPlugin\Command\SebSept\Contract;
+namespace SebSept\PsDevToolsPlugin\Command\Contract;
 
 /**
  * Interface PreCommitRegistrableCommand.
@@ -30,5 +30,5 @@ interface PreCommitRegistrableCommand
     /**
      * Contents to write inside composer.json file, in the pre-commit script.
      */
-    public function getComposerPrecommitScriptContent(): string;
+    public function getComposerPrecommitScriptContent(): ?string;
 }

--- a/src/Command/PrestashopDevTools/PrestashopDevToolsCsFixer.php
+++ b/src/Command/PrestashopDevTools/PrestashopDevToolsCsFixer.php
@@ -22,9 +22,10 @@ namespace SebSept\PsDevToolsPlugin\Command\PrestashopDevTools;
 
 use Composer\Util\Filesystem;
 use RuntimeException;
+use SebSept\PsDevToolsPlugin\Command\Contract\PreCommitRegistrableCommand;
 use Symfony\Component\Process\Process;
 
-final class PrestashopDevToolsCsFixer extends PrestashopDevTools
+final class PrestashopDevToolsCsFixer extends PrestashopDevTools implements PreCommitRegistrableCommand
 {
     const PHP_CS_CONFIGURATION_FILE = '/.php_cs.dist';
 
@@ -91,5 +92,12 @@ HELP
         $this->getIO()->info(' https://github.com/PrestaShop/php-dev-tools/issues/58');
 
         $this->addComposerScript(['php-cs-fixer fix']);
+    }
+
+    public function getComposerPrecommitScriptContent(): ?string
+    {
+        return $this->isToolConfigured() && $this->isComposerScriptDefined()
+            ? 'vendor/bin/php-cs-fixer fix --dry-run --ansi'
+            : null;
     }
 }

--- a/src/Command/PrestashopDevTools/PrestashopDevToolsPhpStan.php
+++ b/src/Command/PrestashopDevTools/PrestashopDevToolsPhpStan.php
@@ -23,9 +23,10 @@ namespace SebSept\PsDevToolsPlugin\Command\PrestashopDevTools;
 use Composer\Util\Filesystem;
 use Exception;
 use RuntimeException;
+use SebSept\PsDevToolsPlugin\Command\Contract\PreCommitRegistrableCommand;
 use Symfony\Component\Process\Process;
 
-final class PrestashopDevToolsPhpStan extends PrestashopDevTools
+final class PrestashopDevToolsPhpStan extends PrestashopDevTools implements PreCommitRegistrableCommand
 {
     const PHPSTAN_CONFIGURATION_FILE = '/phpstan.neon';
 
@@ -137,5 +138,10 @@ HELP
         $this->addComposerScript([
             "@putenv _PS_ROOT_DIR_=$prestashopPath",
             'phpstan analyse', ]);
+    }
+
+    public function getComposerPrecommitScriptContent(): ?string
+    {
+        return $this->isToolConfigured() && $this->isComposerScriptDefined() ? '@phpstan' : null;
     }
 }

--- a/src/Command/SebSept/Contract/PreCommitRegistrableCommand.php
+++ b/src/Command/SebSept/Contract/PreCommitRegistrableCommand.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * SebSept Ps_dev_base - Tools for quality Prestashop Module development.
+ *
+ * Copyright (c) 2021 Sébastien Monterisi
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/MIT
+ *
+ * @author    Sébastien Monterisi <contact@seb7.fr>
+ * @copyright since 2021 Sébastien Monterisi
+ * @license   https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace SebSept\PsDevToolsPlugin\Command\SebSept\Contract;
+
+/**
+ * Interface PreCommitRegistrableCommand.
+ *
+ * The command which implements this interface can be registered inside the composer 'pre-commit' script
+ */
+interface PreCommitRegistrableCommand
+{
+    /**
+     * Contents to write inside composer.json file, in the pre-commit script.
+     */
+    public function getComposerPrecommitScriptContent(): string;
+}

--- a/src/Command/SebSept/PrecommitHook.php
+++ b/src/Command/SebSept/PrecommitHook.php
@@ -213,9 +213,9 @@ HELP
 Before the next commit the git precommit hook will be triggered.
 If the pre-commit script return 0 (success), commit will be performed, otherwise aborted.
 In case, you can't read the precommit script output and find what's wrong
-just run <info>composer psdt:pre-commit</info> .
+just run <info>composer run-script pre-commit</info> .
 
-You can also run this command at any time, before processing the commit, stashing changes for example.
+Run this command at any time, before processing the commit, stashing changes for example.
 You can edit the script content by editing the script entry <info>pre-commit</info> in <comment>composer.json</comment>.
 INFOS;
     }

--- a/src/Command/SebSept/PrecommitHook.php
+++ b/src/Command/SebSept/PrecommitHook.php
@@ -22,8 +22,8 @@ namespace SebSept\PsDevToolsPlugin\Command\SebSept;
 
 use Composer\Command\BaseCommand as ComposerBaseCommand;
 use Exception;
+use SebSept\PsDevToolsPlugin\Command\Contract\PreCommitRegistrableCommand;
 use SebSept\PsDevToolsPlugin\Command\ScriptCommand;
-use SebSept\PsDevToolsPlugin\Command\SebSept\Contract\PreCommitRegistrableCommand;
 use SebSept\PsDevToolsPlugin\Composer\PsDevToolsCommandProvider;
 use SplFileInfo;
 use Symfony\Component\Console\Input\InputInterface;
@@ -138,11 +138,13 @@ HELP
             return $commands;
         }, []);
 
-        $scripts = array_map(
-            static function (PreCommitRegistrableCommand $command) {
-                return $command->getComposerPrecommitScriptContent();
-            },
-            $preCommitRegistrableCommands
+        $scripts = array_filter(
+            array_map(
+                static function (PreCommitRegistrableCommand $command) {
+                    return $command->getComposerPrecommitScriptContent();
+                },
+                $preCommitRegistrableCommands
+            )
         );
         $scripts[] = 'composer validate';
 


### PR DESCRIPTION
Problems : 
- The Precommit command is responsible for declaring which commands can be included, it's better if the commands themself declare that.
- composer scripts `pre-commit` contents are defined inside the PrecommitHook Command, it's also the responsability of the commands to do it

After the refactoring, the problems above will be resolved, the Precommit command will not change if the precommitable commands change their scripts, are added or removed.